### PR TITLE
Separator argument added.

### DIFF
--- a/slugify/__init__.py
+++ b/slugify/__init__.py
@@ -23,7 +23,7 @@ REPLACE1_REXP = re.compile(r'[\']+')
 REPLACE2_REXP = re.compile(r'[^-a-z0-9]+')
 REMOVE_REXP = re.compile('-{2,}')
 
-def smart_truncate(text, max_length=0, word_boundaries=False,separator='-'):
+def smart_truncate(text, max_length=0, word_boundaries=False, separator='-'):
     if not max_length or len(text) < max_length:
         return text
 


### PR DESCRIPTION
I've added 'separator' argument to module, so you can choose which separator to use (by default it is dash). I think it is useful when you want to use another char to slugify your text (for example, sometimes I prefer to use underscore or dot).
