### PR TITLE
Add Python versions to setup.py classifiers.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,12 @@ classifiers = [
     'License :: OSI Approved :: BSD License',
     'Operating System :: POSIX',
     'Programming Language :: Python',
+    'Programming Language :: Python :: 2.6',
+    'Programming Language :: Python :: 2.7',
+    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.2',
+    'Programming Language :: Python :: 3.3',
+    'Programming Language :: Python :: 3.4',
 ]
 
 


### PR DESCRIPTION
This should let caniusepython3 detect that it’s Python-3-ready.