### PR TITLE
unichr is not defined in python 3

### DIFF
--- a/slugify/slugify.py
+++ b/slugify/slugify.py
@@ -11,6 +11,7 @@ except ImportError:
     from html.entities import name2codepoint
     _unicode = str
     _unicode_type = str
+    unichr = chr
 
 import unidecode
 

--- a/test.py
+++ b/test.py
@@ -131,6 +131,11 @@ class TestSlugification(unittest.TestCase):
         r = slugify(txt, stopwords=['the', 'in', 'a', 'hurry'])
         self.assertEqual(r, 'quick-brown-fox-jumps-over-lazy-dog')
 
+    def test_html_entities(self):
+        txt = 'foo &amp; bar'
+        r = slugify(txt)
+        self.assertEqual(r, 'foo-bar')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
With python 3.*:
```
>>> slugify.slugify('test &amp; test')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/arthur/Documents/reaaad/pyregrinate/.venv/lib/python3.4/site-packages/slugify/slugify.py", line 104, in slugify
    text = CHAR_ENTITY_REXP.sub(lambda m: unichr(name2codepoint[m.group(1)]), text)
  File "/Users/arthur/Documents/reaaad/pyregrinate/.venv/lib/python3.4/site-packages/slugify/slugify.py", line 104, in <lambda>
    text = CHAR_ENTITY_REXP.sub(lambda m: unichr(name2codepoint[m.group(1)]), text)
NameError: name 'unichr' is not defined
```