### PR TITLE
Stopword replacement bug (different separators)

### DIFF
--- a/slugify/slugify.py
+++ b/slugify/slugify.py
@@ -129,8 +129,8 @@ def slugify(text, entities=True, decimal=True, hexadecimal=True, max_length=0, w
     # remove stopwords
     if stopwords:
         stopwords_lower = [s.lower() for s in stopwords]
-        words = [w for w in text.split(separator) if w not in stopwords_lower]
-        text = separator.join(words)
+        words = [w for w in text.split('-') if w not in stopwords_lower]
+        text = '-'.join(words)
 
     # smart truncate if requested
     if max_length > 0:

--- a/test.py
+++ b/test.py
@@ -131,6 +131,11 @@ class TestSlugification(unittest.TestCase):
         r = slugify(txt, stopwords=['the', 'in', 'a', 'hurry'])
         self.assertEqual(r, 'quick-brown-fox-jumps-over-lazy-dog')
 
+    def test_stopwords_with_different_separator(self):
+        txt = 'the quick brown fox jumps over the lazy dog'
+        r = slugify(txt, stopwords=['the'], separator=' ')
+        self.assertEqual(r, 'quick brown fox jumps over lazy dog')
+
     def test_html_entities(self):
         txt = 'foo &amp; bar'
         r = slugify(txt)


### PR DESCRIPTION
Just like it says in the title. Whenever I wanted to remove stopwords with a seperator other than '-' nothing happend. 
I just changed the split criteria to '-', because the separator replacement is done later.