### PR TITLE
Create MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include LICENSE.md
+include README.md
+include requirements.txt


### PR DESCRIPTION
Add the license (and other files) to MANIFEST.in so that it will be included in sdists and other packages.
This came up during packaging of python-slugify for [conda-forge](https://conda-forge.github.io).