### PR TITLE
Added possibility to include custom regex as allowed characters

### DIFF
--- a/slugify/slugify.py
+++ b/slugify/slugify.py
@@ -24,7 +24,6 @@ DECIMAL_PATTERN = re.compile('&#(\d+);')
 HEX_PATTERN = re.compile('&#x([\da-fA-F]+);')
 QUOTE_PATTERN = re.compile(r'[\']+')
 ALLOWED_CHARS_PATTERN = re.compile(r'[^-a-z0-9]+')
-ALLOWED_CHARS_WITH_UNDERSCORE = re.compile(r'[^-a-z0-9_]+')
 DUPLICATE_DASH_PATTERN = re.compile('-{2,}')
 NUMBERS_PATTERN = re.compile('(?<=\d),(?=\d)')
 
@@ -72,7 +71,7 @@ def smart_truncate(string, max_length=0, word_boundaries=False, separator=' ', s
 
 
 def slugify(text, entities=True, decimal=True, hexadecimal=True, max_length=0, word_boundary=False,
-            separator='-', save_order=False, stopwords=(), allow_underscore=False):
+            separator='-', save_order=False, stopwords=(), allowed_characters=None):
     """
     Make a slug from the given text.
     :param text (str): initial text
@@ -132,11 +131,11 @@ def slugify(text, entities=True, decimal=True, hexadecimal=True, max_length=0, w
 
     # replace unwanted characters
     text = NUMBERS_PATTERN.sub('', text)
-    if allow_underscore:
-        allowed_pattern = ALLOWED_CHARS_WITH_UNDERSCORE
+    print(text)
+    if allowed_characters:
+        text = re.sub(allowed_characters, '-', text)
     else:
-        allowed_pattern = ALLOWED_CHARS_PATTERN
-    text = allowed_pattern.sub('-', text)
+        text = ALLOWED_CHARS_PATTERN.sub('-', text)
 
     # remove redundant -
     text = DUPLICATE_DASH_PATTERN.sub('-', text).strip('-')

--- a/slugify/slugify.py
+++ b/slugify/slugify.py
@@ -24,6 +24,7 @@ DECIMAL_PATTERN = re.compile('&#(\d+);')
 HEX_PATTERN = re.compile('&#x([\da-fA-F]+);')
 QUOTE_PATTERN = re.compile(r'[\']+')
 ALLOWED_CHARS_PATTERN = re.compile(r'[^-a-z0-9]+')
+ALLOWED_CHARS_WITH_UNDERSCORE = re.compile(r'[^-a-z0-9_]+')
 DUPLICATE_DASH_PATTERN = re.compile('-{2,}')
 NUMBERS_PATTERN = re.compile('(?<=\d),(?=\d)')
 
@@ -71,7 +72,7 @@ def smart_truncate(string, max_length=0, word_boundaries=False, separator=' ', s
 
 
 def slugify(text, entities=True, decimal=True, hexadecimal=True, max_length=0, word_boundary=False,
-            separator='-', save_order=False, stopwords=()):
+            separator='-', save_order=False, stopwords=(), allow_underscore=False):
     """
     Make a slug from the given text.
     :param text (str): initial text
@@ -131,7 +132,11 @@ def slugify(text, entities=True, decimal=True, hexadecimal=True, max_length=0, w
 
     # replace unwanted characters
     text = NUMBERS_PATTERN.sub('', text)
-    text = ALLOWED_CHARS_PATTERN.sub('-', text)
+    if allow_underscore:
+        allowed_pattern = ALLOWED_CHARS_WITH_UNDERSCORE
+    else:
+        allowed_pattern = ALLOWED_CHARS_PATTERN
+    text = allowed_pattern.sub('-', text)
 
     # remove redundant -
     text = DUPLICATE_DASH_PATTERN.sub('-', text).strip('-')

--- a/test.py
+++ b/test.py
@@ -167,6 +167,11 @@ class TestSlugification(unittest.TestCase):
         r = slugify(txt)
         self.assertEqual(r, '1000-reasons-you-are-1')
 
+    def test_underscore(self):
+        txt = "___This is a test___"
+        r = slugify(txt, allow_underscore=True)
+        self.assertEqual(r, "___this-is-a-test___")
+
 
 class TestUtils(unittest.TestCase):
 

--- a/test.py
+++ b/test.py
@@ -169,7 +169,7 @@ class TestSlugification(unittest.TestCase):
 
     def test_underscore(self):
         txt = "___This is a test___"
-        r = slugify(txt, allow_underscore=True)
+        r = slugify(txt, allowed_characters=r'[^-a-z0-9_]+')
         self.assertEqual(r, "___this-is-a-test___")
 
 


### PR DESCRIPTION
Encountered situation in my daily work where passing custom regex for allowed characters was needed (for example underscore _ ). I made a small rework that would stay backwards compatible but would still allow for parameter to be passed to alter this if needed.