### PR TITLE
Closes #38: use find_packages() rather than home-grown get_packages and get_package_data

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,0 @@
-include LICENSE
-include README.rst
-include requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # -*- coding: utf-8 -*-
-from setuptools import setup
+from setuptools import setup, find_packages
 import re
 import os
 import sys
@@ -41,31 +41,6 @@ def get_version(package):
     return re.search("^__version__ = ['\"]([^'\"]+)['\"]", init_py, re.MULTILINE).group(1)
 
 
-def get_packages(package):
-    """
-    Return root package and all sub-packages.
-    """
-    return [dirpath
-            for dirpath, dirnames, filenames in os.walk(package)
-            if os.path.exists(os.path.join(dirpath, '__init__.py'))]
-
-
-def get_package_data(package):
-    """
-    Return all files under the root package, that are not in a
-    package themselves.
-    """
-    walk = [(dirpath.replace(package + os.sep, '', 1), filenames)
-            for dirpath, dirnames, filenames in os.walk(package)
-            if not os.path.exists(os.path.join(dirpath, '__init__.py'))]
-
-    filepaths = []
-    for base, filenames in walk:
-        filepaths.extend([os.path.join(base, filename)
-                          for filename in filenames])
-    return {package: filepaths}
-
-
 if sys.argv[-1] == 'publish':
     os.system("python setup.py sdist upload")
     args = {'version': get_version(package)}
@@ -82,8 +57,7 @@ setup(
     description=description,
     author=author,
     author_email=author_email,
-    packages=get_packages(package),
-    package_data=get_package_data(package),
+    packages=find_packages(),
     install_requires=install_requires,
     classifiers=classifiers,
     entry_points={'console_scripts': ['slugify=slugify.slugify:main']},


### PR DESCRIPTION
I think that you don't need MANIFEST.in and that you can use setuptools' find_packages.

Does this PR work for you?