### PR TITLE
Create MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include CHANGELOG.md
+include LICENSE
+include README.rst


### PR DESCRIPTION
Add the `LICENSE` and other files to `MANIFEST.in` so that they will be included in sdists and other packages.
This came up during packaging of `python-slugify` for `conda-forge`.

Also please submit a new release to pypi so this change will be tracked.
