### PR TITLE
Use the actual separator in code

### DIFF
--- a/test.py
+++ b/test.py
@@ -89,7 +89,7 @@ class TestSlugification(unittest.TestCase):
     def test_multi_character_separator(self):
         txt = 'jaja---lol-méméméoo--a'
         r = slugify(txt, max_length=20, word_boundary=True, separator="ZZZZZZ")
-        self.assertEqual(r, "jajaZZZZZZlolZZZZZZmememeooZZZZZZa")
+        self.assertEqual(r, "jajaZZZZZZlolZZZZZZa")
 
     def test_save_order(self):
         txt = 'one two three four five'
@@ -182,7 +182,7 @@ class TestSlugification(unittest.TestCase):
         txt = "___This is a test___"
         regex_pattern = r'[^-a-z0-9_]+'
         r = slugify(txt, separator='_', regex_pattern=regex_pattern)
-        self.assertNotEqual(r, "_this_is_a_test_")
+        self.assertEqual(r, "this_is_a_test")
 
 
 class TestUtils(unittest.TestCase):

--- a/test.py
+++ b/test.py
@@ -184,6 +184,19 @@ class TestSlugification(unittest.TestCase):
         r = slugify(txt, separator='_', regex_pattern=regex_pattern)
         self.assertEqual(r, "this_is_a_test")
 
+    def test_separator_remove_hyphens(self):
+        """With an overridden separator, hyphens should be stripped."""
+        txt = "___This is a hyphen-containing test."
+        r = slugify(txt, separator='_')
+        self.assertEqual(r, "this_is_a_hyphen_containing_test")
+
+    def test_regex_pattern_allow_hyphens(self):
+        """With an overridden separator and a regex, it should be possible to preserve hyphens."""
+        txt = "___This is a hyphen-containing test."
+        regex_pattern = r'[^-a-z0-9_]+'
+        r = slugify(txt, separator='_', regex_pattern=regex_pattern)
+        self.assertEqual(r, "this_is_a_hyphen-containing_test")
+
 
 class TestUtils(unittest.TestCase):
 


### PR DESCRIPTION
The underlying motivation for this is that I wanted to be able to slugify text that contains hyphens and keep the hyphens.  It seemed like that should work with
```
slugify('hyphen-having text FTW!', separator='_', regex_pattern=r'[^-a-z0-9]')
```
i.e. that that should produce 'hyphen-having_text_ftw'.  In fact it produced 'hyphen_having_text_ftw' because, behind the scenes, this was always using hyphen as the separator, just switching it out and the end if the separator was overridden, which means hyphen couldn't be an allowed character.

This changes it to use the specified separator from the beginning.

One side effect of this is that the test with a multi-character separator and `max_length=20` produces a different result, because the multi-character separator counts against the length.  This seems like an improvement to me.