### PR TITLE
Support for case sensitivity

### DIFF
--- a/test.py
+++ b/test.py
@@ -113,6 +113,11 @@ class TestSlugification(unittest.TestCase):
         r = slugify(txt, stopwords=['stopword'])
         self.assertEqual(r, 'this-has-a')
 
+    def test_stopword_removal_casesensitive(self):
+        txt = 'thIs Has a stopword Stopword'
+        r = slugify(txt, stopwords=['Stopword'], lowercase=False)
+        self.assertEqual(r, 'thIs-Has-a-stopword')
+
     def test_multiple_stopword_occurances(self):
         txt = 'the quick brown fox jumps over the lazy dog'
         r = slugify(txt, stopwords=['the'])


### PR DESCRIPTION
`slugify.slugify` receives a new keyword argument, `lowercase`. It's set to `True` by default, preserving the original behavior. If set to `False`, slugify will preserve uppercase letters. This functionality also extends to the `stopwords` keyword argument.

```python
out_str = slugify(slug_str, lowercase = False)
```

I added one new test ... it could probably be more.