### PR TITLE
Test against Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
-sudo: false
 language: python
+dist: xenial
 
 python:
   - "2.7"
   - "3.4"
   - "3.5"
   - "3.6"
-  - pypy
+  - "3.7"
+  - "pypy2.7-6.0"
 
 install:
   - pip install pip -U

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ classifiers = [
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
 ]
 
 


### PR DESCRIPTION
Also, remove `sudo: false` because TravisCI has
migrated to their VM-based infrastructure:

https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration