### PR TITLE
bumped dependency text-unidecode to v1.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ url = 'https://github.com/un33k/python-slugify'
 author = 'Val Neekman'
 author_email = 'info@neekware.com'
 license = 'MIT'
-install_requires = ['text-unidecode==1.2']
+install_requires = ['text-unidecode==1.3']
 extras_require = {'unidecode': ['Unidecode==1.0.23']}
 
 classifiers = [


### PR DESCRIPTION
Hi, I've enjoyed using this library.

Recently, there's a version update from the text-unidecode dependency to version v1.3
https://github.com/kmike/text-unidecode/

I am also using faker https://github.com/joke2k/faker as part of my dev environment, and they have updated to using text-unidecode v1.3

This causes a clash in python-slugify's dependency text-unidecode , needing `text-unidecode==1.2` VS faker needing `text-unidecode==1.3`.

I updated the dependency requirement to v1.3, and ran `python test.py`. All tests passed.

Cheers,
VKen