### PR TITLE
Update tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{39,38,37,36,35},pypy3
+envlist = py{39,38,37,36},pypy3
 
 [testenv]
 deps=


### PR DESCRIPTION
Drop completly from tox.ini file Python3.5 for testing according to [CHANGELOG](https://github.com/un33k/python-slugify/blob/master/CHANGELOG.md#500).
More information about it at [commit which should drop Python 3.5](https://github.com/un33k/python-slugify/commit/319559cb43f239ac0d3bc7b975a78059bf4a1086)