### PR TITLE
Simplify python_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
     packages=find_packages(exclude=EXCLUDE_FROM_PACKAGES),
     install_requires=install_requires,
     extras_require=extras_require,
-    python_requires='!=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*',
+    python_requires='>=3.6',
     classifiers=classifiers,
     entry_points={'console_scripts': ['slugify=slugify.__main__:main']},
 )


### PR DESCRIPTION
Related for dropping support for Python 2 and Python <3.6
More information about it at [commit which should drop Python 3.5](https://github.com/un33k/python-slugify/commit/319559cb43f239ac0d3bc7b975a78059bf4a1086)