### PR TITLE
`unidecode` vs `text_unidecode` import resolution order

### DIFF
--- a/slugify/slugify.py
+++ b/slugify/slugify.py
@@ -4,9 +4,9 @@ import unicodedata
 from html.entities import name2codepoint
 
 try:
-    import text_unidecode as unidecode
-except ImportError:
     import unidecode
+except ImportError:
+    import text_unidecode as unidecode
 
 __all__ = ['slugify', 'smart_truncate']
 


### PR DESCRIPTION
AS is `text_unidecode` is install_requires it is always present in the python environment,  it makes sense to try import optinal dependency `unidecode` first, and only then fallback to `text_unidecode`.

The way the code is now `unidecode` library is just getting ignored.