### PR TITLE
Replace flake8 and pycodestyle with ruff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .
-          pip install -t dev.requirements.txt
+          pip install -r dev.requirements.txt
           pip install --upgrade coveralls
       - name: Run ruff
         run: ruff --exclude=build --format=github

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,10 @@ jobs:
           pip install coveralls --upgrade
       - name: Run flake8
         run: |
-          pip install flake8 --upgrade
-          flake8 --exclude=build --ignore=E501,F403,F401,E241,E225,E128 .
-      - name: Run pycodestyle
-        run: |
-          pip install pycodestyle --upgrade
-          pycodestyle --ignore=E128,E261,E225,E501,W605 slugify test.py setup.py
+          pip install --upgrade ruff
+          ruff --exclude=build --format=github
+               --select="A,B,DJ,E,F,PLC,PLE,PLW,W"
+               --ignore=F401,F403 --line-length=117 .
       - name: Run test
         run: |
           coverage run --source=slugify test.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .
           pip install coveralls --upgrade
-      - name: Run flake8
+      - name: Run ruff
         run: |
           pip install --upgrade ruff
           ruff --exclude=build --format=github

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.7, 3.8, 3.9, "3.10", 3.11, pypy3.8]
+        python: [3.7, 3.8, 3.9, "3.10", 3.11, pypy3.9]
 
     steps:
       - uses: actions/checkout@v3
@@ -22,20 +22,20 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
+          cache: 'pip'
+          check-latest: true
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -e .
-          pip install coveralls --upgrade
+          pip install -t dev.requirements.txt
+          pip install --upgrade coveralls
       - name: Run ruff
-        run: |
-          pip install --upgrade ruff
-          ruff --exclude=build --format=github
-               --select="A,B,DJ,E,F,PLC,PLE,PLW,W"
-               --ignore=F401,F403 --line-length=117 .
+        run: ruff --exclude=build --format=github
+                  --select="A,B,DJ,E,F,PLC,PLE,PLW,W"
+                  --ignore=F401,F403 --line-length=117 .
       - name: Run test
-        run: |
-          coverage run --source=slugify test.py
+        run: coverage run --source=slugify test.py
       - name: Coveralls
         run: coveralls --service=github
         env:

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.7, 3.8, 3.9, "3.10", 3.11, pypy3.8]
+        python: [3.7, 3.8, 3.9, "3.10", 3.11, pypy3.9]
 
     steps:
       - uses: actions/checkout@v3
@@ -22,22 +22,20 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
+          cache: 'pip'
+          check-latest: true
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -e .
-          pip install coveralls --upgrade
-      - name: Run flake8
-        run: |
-          pip install flake8 --upgrade
-          flake8 --exclude=build --ignore=E501,F403,F401,E241,E225,E128 .
-      - name: Run pycodestyle
-        run: |
-          pip install pycodestyle --upgrade
-          pycodestyle --ignore=E128,E261,E225,E501,W605 slugify test.py setup.py
+          pip install -r dev.requirements.txt
+          pip install --upgrade coveralls
+      - name: Run ruff
+        run: ruff --exclude=build --format=github
+                  --select="A,B,DJ,E,F,PLC,PLE,PLW,W"
+                  --ignore=F401,F403 --line-length=117 .
       - name: Run test
-        run: |
-          coverage run --source=slugify test.py
+        run: coverage run --source=slugify test.py
       - name: Coveralls
         run: coveralls --service=github
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.7, 3.8, 3.9, "3.10", 3.11, pypy3.8]
+        python: [3.7, 3.8, 3.9, "3.10", 3.11, pypy3.9]
 
     steps:
       - uses: actions/checkout@v3
@@ -21,22 +21,20 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
+          cache: 'pip'
+          check-latest: true
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -e .
-          pip install coveralls --upgrade
-      - name: Run flake8
-        run: |
-          pip install flake8 --upgrade
-          flake8 --exclude=build --ignore=E501,F403,F401,E241,E225,E128 .
-      - name: Run pycodestyle
-        run: |
-          pip install pycodestyle --upgrade
-          pycodestyle --ignore=E128,E261,E225,E501,W605 slugify test.py setup.py
+          pip install -r dev.requirements.txt
+          pip install --upgrade coveralls
+      - name: Run ruff
+        run: ruff --exclude=build --format=github
+                  --select="A,B,DJ,E,F,PLC,PLE,PLW,W"
+                  --ignore=F401,F403 --line-length=117 .
       - name: Run test
-        run: |
-          coverage run --source=slugify test.py
+        run: coverage run --source=slugify test.py
       - name: Coveralls
         run: coveralls --service=github
         env:

--- a/dev.requirements.txt
+++ b/dev.requirements.txt
@@ -1,3 +1,2 @@
-pycodestyle==2.8.0
-twine==3.4.1
-flake8==4.0.1
+ruff==0.0.285
+twine==4.0.2


### PR DESCRIPTION
[Ruff](https://beta.ruff.rs) supports [over 500 lint rules](https://beta.ruff.rs/docs/rules) including bandit, flake8, isort, pylint, and pyupgrade and is written in Rust for speed.
Also added rules for pylint conventions, pylint errors, and pylint warnings.