### PR TITLE
Fix CI to run on master without duplicate push and pull_request runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,14 @@
 name: CI
 
-# Run on push only for dev/sandbox
-# Otherwise it may trigger concurrently `push & pull_request` on PRs.
 on:
   push:
     branches:
       - ci
+      - master
       - staging
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build:


### PR DESCRIPTION
That weird construct under `on:` allows the GHA to run on push OR pull_request to the `master` branch but NOT both.