### PR TITLE
Enables mypy --strict and adds corresponding types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,10 @@ jobs:
       - name: Run test
         run: |
           coverage run --source=slugify test.py
+      - name: Run mypy
+        run: |
+          pip install mypy --upgrade
+          mypy .
       - name: Coveralls
         run: coveralls --service=github
         env:

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -38,6 +38,10 @@ jobs:
       - name: Run test
         run: |
           coverage run --source=slugify test.py
+      - name: Run mypy
+        run: |
+          pip install mypy --upgrade
+          mypy .
       - name: Coveralls
         run: coveralls --service=github
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,10 @@ jobs:
       - name: Run test
         run: |
           coverage run --source=slugify test.py
+      - name: Run mypy
+        run: |
+          pip install mypy --upgrade
+          mypy .
       - name: Coveralls
         run: coveralls --service=github
         env:

--- a/dev.requirements.txt
+++ b/dev.requirements.txt
@@ -1,3 +1,4 @@
 pycodestyle==2.8.0
 twine==3.4.1
 flake8==4.0.1
+mypy==1.4.1

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+strict = true

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python
 # Learn more: https://github.com/un33k/setup.py
+from __future__ import annotations
+
 import os
 import sys
+from typing import Any
 
 from codecs import open
 from shutil import rmtree
-from setuptools import setup
+from setuptools import setup  # type: ignore[import]
 
 
 package = 'slugify'
@@ -14,9 +17,9 @@ here = os.path.abspath(os.path.dirname(__file__))
 
 install_requires = ['text-unidecode>=1.3']
 extras_requires = {'unidecode': ['Unidecode>=1.1.1']}
-test_requires = []
+test_requires: list[str] = []
 
-about = {}
+about: dict[str, Any] = {}
 with open(os.path.join(here, package, '__version__.py'), 'r', 'utf-8') as f:
     exec(f.read(), about)
 
@@ -24,7 +27,7 @@ with open('README.md', 'r', 'utf-8') as f:
     readme = f.read()
 
 
-def status(s):
+def status(s: str) -> None:
     print('\033[1m{0}\033[0m'.format(s))
 
 
@@ -58,7 +61,7 @@ setup(
     url=about['__url__'],
     license=about['__license__'],
     packages=[package],
-    package_data={'': ['LICENSE']},
+    package_data={'': ['LICENSE', 'py.typed']},
     package_dir={'slugify': 'slugify'},
     include_package_data=True,
     python_requires=python_requires,

--- a/slugify/__main__.py
+++ b/slugify/__main__.py
@@ -1,11 +1,11 @@
-from __future__ import print_function, absolute_import
+from __future__ import print_function, absolute_import, annotations
 import argparse
 import sys
 
-from .slugify import slugify, DEFAULT_SEPARATOR
+from .slugify import slugify, SlugifyParams, DEFAULT_SEPARATOR
 
 
-def parse_args(argv):
+def parse_args(argv: list[str] | None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Slug string")
 
     input_group = parser.add_argument_group(description="Input")
@@ -39,13 +39,13 @@ def parse_args(argv):
     parser.add_argument("--allow-unicode", action='store_true', default=False,
                         help="Allow unicode characters")
 
-    args = parser.parse_args(argv[1:])
+    args = parser.parse_args(argv[1:] if argv else [])
 
     if args.input_string and args.stdin:
         parser.error("Input strings and --stdin cannot work together")
 
     if args.replacements:
-        def split_check(repl):
+        def split_check(repl: str) -> list[str]:
             SEP = '->'
             if SEP not in repl:
                 parser.error("Replacements must be of the form: ORIGINAL{SEP}REPLACED".format(SEP=SEP))
@@ -63,7 +63,8 @@ def parse_args(argv):
     return args
 
 
-def slugify_params(args):
+# TODO: Convert params to a TypedDict or preferably a NamedTuple.
+def slugify_params(args: argparse.Namespace) -> SlugifyParams:
     return dict(
         text=args.input_string,
         entities=args.entities,
@@ -80,14 +81,16 @@ def slugify_params(args):
     )
 
 
-def main(argv=None):  # pragma: no cover
+def main(argv: list[str] | None = None) -> None:  # pragma: no cover
     """ Run this program """
     if argv is None:
         argv = sys.argv
     args = parse_args(argv)
     params = slugify_params(args)
     try:
-        print(slugify(**params))
+        # TODO: Mypy is unable to infer the type of each param after spreading.
+        # It's possible this is resolved using typing_extension's TypedDict.
+        print(slugify(**params))  # type: ignore[arg-type]
     except KeyboardInterrupt:
         sys.exit(-1)
 

--- a/slugify/slugify.py
+++ b/slugify/slugify.py
@@ -1,14 +1,21 @@
+from __future__ import annotations
+
 import re
 import sys
 import unicodedata
 from html.entities import name2codepoint
+from typing import Dict, Iterable, List, Union
+
 
 try:
-    import unidecode
+    import unidecode  # type: ignore[import]
 except ImportError:
-    import text_unidecode as unidecode
+    import text_unidecode as unidecode  # type: ignore[import]
 
 __all__ = ['slugify', 'smart_truncate']
+
+
+SlugifyParams = Dict[str, Union[str, bool, int, Iterable[str], Iterable[Iterable[str]], None]]
 
 
 CHAR_ENTITY_PATTERN = re.compile(r'&(%s);' % '|'.join(name2codepoint))
@@ -22,7 +29,8 @@ NUMBERS_PATTERN = re.compile(r'(?<=\d),(?=\d)')
 DEFAULT_SEPARATOR = '-'
 
 
-def smart_truncate(string, max_length=0, word_boundary=False, separator=' ', save_order=False):
+def smart_truncate(string: str, max_length: int = 0, word_boundary: bool = False,
+                   separator: str = ' ', save_order: bool = False) -> str:
     """
     Truncate a string.
     :param string (str): string for modification
@@ -64,9 +72,11 @@ def smart_truncate(string, max_length=0, word_boundary=False, separator=' ', sav
     return truncated.strip(separator)
 
 
-def slugify(text, entities=True, decimal=True, hexadecimal=True, max_length=0, word_boundary=False,
-            separator=DEFAULT_SEPARATOR, save_order=False, stopwords=(), regex_pattern=None, lowercase=True,
-            replacements=(), allow_unicode=False):
+def slugify(text: str, entities: bool = True, decimal: bool = True, hexadecimal: bool = True,
+            max_length: int = 0, word_boundary: bool = False, separator: str = DEFAULT_SEPARATOR,
+            save_order: bool = False, stopwords: Iterable[str] = (),
+            regex_pattern: str | None = None, lowercase: bool = True,
+            replacements: Iterable[Iterable[str]] = (), allow_unicode: bool = False) -> str:
     """
     Make a slug from the given text.
     :param text (str): initial text

--- a/slugify/special.py
+++ b/slugify/special.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
+from __future__ import annotations
 
 
-def add_uppercase_char(char_list):
+def add_uppercase_char(char_list: list[tuple[str, str]]) -> list[tuple[str, str]]:
     """ Given a replacement char list, this adds uppercase chars to the list """
 
     for item in char_list:
@@ -10,6 +11,7 @@ def add_uppercase_char(char_list):
         if upper_dict not in char_list and char != upper_dict[0]:
             char_list.insert(0, upper_dict)
         return char_list
+    raise RuntimeError("char_list must not be empty")
 
 
 # Language specific pre translations

--- a/test.py
+++ b/test.py
@@ -1,17 +1,24 @@
 # -*- coding: utf-8 -*-
+from __future__ import annotations
+
 import io
 import sys
+from typing import Any, TYPE_CHECKING
 import unittest
+from unittest import mock
 from contextlib import contextmanager
 
 from slugify import slugify
 from slugify import smart_truncate
 from slugify.__main__ import slugify_params, parse_args
 
+if TYPE_CHECKING:
+    from slugify.slugify import SlugifyParams
+
 
 class TestSlugify(unittest.TestCase):
 
-    def test_extraneous_seperators(self):
+    def test_extraneous_seperators(self) -> None:
 
         txt = "This is a test ---"
         r = slugify(txt)
@@ -25,17 +32,17 @@ class TestSlugify(unittest.TestCase):
         r = slugify(txt)
         self.assertEqual(r, "this-is-a-test")
 
-    def test_non_word_characters(self):
+    def test_non_word_characters(self) -> None:
         txt = "This -- is a ## test ---"
         r = slugify(txt)
         self.assertEqual(r, "this-is-a-test")
 
-    def test_phonetic_conversion_of_eastern_scripts(self):
+    def test_phonetic_conversion_of_eastern_scripts(self) -> None:
         txt = '影師嗎'
         r = slugify(txt)
         self.assertEqual(r, "ying-shi-ma")
 
-    def test_accented_text(self):
+    def test_accented_text(self) -> None:
         txt = 'C\'est déjà l\'été.'
         r = slugify(txt)
         self.assertEqual(r, "c-est-deja-l-ete")
@@ -44,17 +51,17 @@ class TestSlugify(unittest.TestCase):
         r = slugify(txt)
         self.assertEqual(r, "nin-hao-wo-shi-zhong-guo-ren")
 
-    def test_accented_text_with_non_word_characters(self):
+    def test_accented_text_with_non_word_characters(self) -> None:
         txt = 'jaja---lol-méméméoo--a'
         r = slugify(txt)
         self.assertEqual(r, "jaja-lol-mememeoo-a")
 
-    def test_cyrillic_text(self):
+    def test_cyrillic_text(self) -> None:
         txt = 'Компьютер'
         r = slugify(txt)
         self.assertEqual(r, "kompiuter")
 
-    def test_max_length(self):
+    def test_max_length(self) -> None:
         txt = 'jaja---lol-méméméoo--a'
         r = slugify(txt, max_length=9)
         self.assertEqual(r, "jaja-lol")
@@ -63,12 +70,12 @@ class TestSlugify(unittest.TestCase):
         r = slugify(txt, max_length=15)
         self.assertEqual(r, "jaja-lol-mememe")
 
-    def test_max_length_cutoff_not_required(self):
+    def test_max_length_cutoff_not_required(self) -> None:
         txt = 'jaja---lol-méméméoo--a'
         r = slugify(txt, max_length=50)
         self.assertEqual(r, "jaja-lol-mememeoo-a")
 
-    def test_word_boundary(self):
+    def test_word_boundary(self) -> None:
         txt = 'jaja---lol-méméméoo--a'
         r = slugify(txt, max_length=15, word_boundary=True)
         self.assertEqual(r, "jaja-lol-a")
@@ -85,17 +92,17 @@ class TestSlugify(unittest.TestCase):
         r = slugify(txt, max_length=19, word_boundary=True)
         self.assertEqual(r, "jaja-lol-mememeoo-a")
 
-    def test_custom_separator(self):
+    def test_custom_separator(self) -> None:
         txt = 'jaja---lol-méméméoo--a'
         r = slugify(txt, max_length=20, word_boundary=True, separator=".")
         self.assertEqual(r, "jaja.lol.mememeoo.a")
 
-    def test_multi_character_separator(self):
+    def test_multi_character_separator(self) -> None:
         txt = 'jaja---lol-méméméoo--a'
         r = slugify(txt, max_length=20, word_boundary=True, separator="ZZZZZZ")
         self.assertEqual(r, "jajaZZZZZZlolZZZZZZmememeooZZZZZZa")
 
-    def test_save_order(self):
+    def test_save_order(self) -> None:
         txt = 'one two three four five'
         r = slugify(txt, max_length=13, word_boundary=True, save_order=True)
         self.assertEqual(r, "one-two-three")
@@ -112,22 +119,22 @@ class TestSlugify(unittest.TestCase):
         r = slugify(txt, max_length=12, word_boundary=True, save_order=True)
         self.assertEqual(r, "one-two")
 
-    def test_stopword_removal(self):
+    def test_stopword_removal(self) -> None:
         txt = 'this has a stopword'
         r = slugify(txt, stopwords=['stopword'])
         self.assertEqual(r, 'this-has-a')
 
-    def test_stopword_removal_casesensitive(self):
+    def test_stopword_removal_casesensitive(self) -> None:
         txt = 'thIs Has a stopword Stopword'
         r = slugify(txt, stopwords=['Stopword'], lowercase=False)
         self.assertEqual(r, 'thIs-Has-a-stopword')
 
-    def test_multiple_stopword_occurances(self):
+    def test_multiple_stopword_occurances(self) -> None:
         txt = 'the quick brown fox jumps over the lazy dog'
         r = slugify(txt, stopwords=['the'])
         self.assertEqual(r, 'quick-brown-fox-jumps-over-lazy-dog')
 
-    def test_differently_cased_stopword_match(self):
+    def test_differently_cased_stopword_match(self) -> None:
         txt = 'Foo A FOO B foo C'
         r = slugify(txt, stopwords=['foo'])
         self.assertEqual(r, 'a-b-c')
@@ -136,78 +143,78 @@ class TestSlugify(unittest.TestCase):
         r = slugify(txt, stopwords=['FOO'])
         self.assertEqual(r, 'a-b-c')
 
-    def test_multiple_stopwords(self):
+    def test_multiple_stopwords(self) -> None:
         txt = 'the quick brown fox jumps over the lazy dog in a hurry'
         r = slugify(txt, stopwords=['the', 'in', 'a', 'hurry'])
         self.assertEqual(r, 'quick-brown-fox-jumps-over-lazy-dog')
 
-    def test_stopwords_with_different_separator(self):
+    def test_stopwords_with_different_separator(self) -> None:
         txt = 'the quick brown fox jumps over the lazy dog'
         r = slugify(txt, stopwords=['the'], separator=' ')
         self.assertEqual(r, 'quick brown fox jumps over lazy dog')
 
-    def test_html_entities_on(self):
+    def test_html_entities_on(self) -> None:
         txt = 'foo &amp; bar'
         r = slugify(txt)
         self.assertEqual(r, 'foo-bar')
 
-    def test_html_entities_off(self):
+    def test_html_entities_off(self) -> None:
         txt = 'foo &amp; bar'
         r = slugify(txt, entities=False)
         self.assertEqual(r, 'foo-amp-bar')
 
-    def test_html_decimal_on(self):
+    def test_html_decimal_on(self) -> None:
         txt = '&#381;'
         r = slugify(txt, decimal=True)
         self.assertEqual(r, 'z')
 
-    def test_html_decimal_off(self):
+    def test_html_decimal_off(self) -> None:
         txt = '&#381;'
         r = slugify(txt, entities=False, decimal=False)
         self.assertEqual(r, '381')
 
-    def test_html_hexadecimal_on(self):
+    def test_html_hexadecimal_on(self) -> None:
         txt = '&#x17D;'
         r = slugify(txt, hexadecimal=True)
         self.assertEqual(r, 'z')
 
-    def test_html_hexadecimal_off(self):
+    def test_html_hexadecimal_off(self) -> None:
         txt = '&#x17D;'
         r = slugify(txt, hexadecimal=False)
         self.assertEqual(r, 'x17d')
 
-    def test_starts_with_number(self):
+    def test_starts_with_number(self) -> None:
         txt = '10 amazing secrets'
         r = slugify(txt)
         self.assertEqual(r, '10-amazing-secrets')
 
-    def test_contains_numbers(self):
+    def test_contains_numbers(self) -> None:
         txt = 'buildings with 1000 windows'
         r = slugify(txt)
         self.assertEqual(r, 'buildings-with-1000-windows')
 
-    def test_ends_with_number(self):
+    def test_ends_with_number(self) -> None:
         txt = 'recipe number 3'
         r = slugify(txt)
         self.assertEqual(r, 'recipe-number-3')
 
-    def test_numbers_only(self):
+    def test_numbers_only(self) -> None:
         txt = '404'
         r = slugify(txt)
         self.assertEqual(r, '404')
 
-    def test_numbers_and_symbols(self):
+    def test_numbers_and_symbols(self) -> None:
         txt = '1,000 reasons you are #1'
         r = slugify(txt)
         self.assertEqual(r, '1000-reasons-you-are-1')
 
-    def test_regex_pattern_keep_underscore(self):
+    def test_regex_pattern_keep_underscore(self) -> None:
         txt = "___This is a test___"
         regex_pattern = r'[^-a-z0-9_]+'
         r = slugify(txt, regex_pattern=regex_pattern)
         self.assertEqual(r, "___this-is-a-test___")
 
-    def test_regex_pattern_keep_underscore_with_underscore_as_separator(self):
+    def test_regex_pattern_keep_underscore_with_underscore_as_separator(self) -> None:
         """
         The regex_pattern turns the power to the caller.
         Hence the caller must ensure that a custom separator doesn't clash
@@ -218,7 +225,7 @@ class TestSlugify(unittest.TestCase):
         r = slugify(txt, separator='_', regex_pattern=regex_pattern)
         self.assertNotEqual(r, "_this_is_a_test_")
 
-    def test_replacements(self):
+    def test_replacements(self) -> None:
         txt = '10 | 20 %'
         r = slugify(txt, replacements=[['|', 'or'], ['%', 'percent']])
         self.assertEqual(r, "10-or-20-percent")
@@ -227,7 +234,7 @@ class TestSlugify(unittest.TestCase):
         r = slugify(txt, replacements=[['♥', 'amour'], ['🦄', 'licorne']])
         self.assertEqual(r, "i-amour-licorne")
 
-    def test_replacements_german_umlaut_custom(self):
+    def test_replacements_german_umlaut_custom(self) -> None:
         txt = 'ÜBER Über German Umlaut'
         r = slugify(txt, replacements=[['Ü', 'UE'], ['ü', 'ue']])
         self.assertEqual(r, "ueber-ueber-german-umlaut")
@@ -235,7 +242,7 @@ class TestSlugify(unittest.TestCase):
 
 class TestSlugifyUnicode(unittest.TestCase):
 
-    def test_extraneous_seperators(self):
+    def test_extraneous_seperators(self) -> None:
 
         txt = "This is a test ---"
         r = slugify(txt, allow_unicode=True)
@@ -249,17 +256,17 @@ class TestSlugifyUnicode(unittest.TestCase):
         r = slugify(txt, allow_unicode=True)
         self.assertEqual(r, "this-is-a-test")
 
-    def test_non_word_characters(self):
+    def test_non_word_characters(self) -> None:
         txt = "This -- is a ## test ---"
         r = slugify(txt, allow_unicode=True)
         self.assertEqual(r, "this-is-a-test")
 
-    def test_phonetic_conversion_of_eastern_scripts(self):
+    def test_phonetic_conversion_of_eastern_scripts(self) -> None:
         txt = '影師嗎'
         r = slugify(txt, allow_unicode=True)
         self.assertEqual(r, txt)
 
-    def test_accented_text(self):
+    def test_accented_text(self) -> None:
         txt = 'C\'est déjà l\'été.'
         r = slugify(txt, allow_unicode=True)
         self.assertEqual(r, "c-est-déjà-l-été")
@@ -268,17 +275,17 @@ class TestSlugifyUnicode(unittest.TestCase):
         r = slugify(txt, allow_unicode=True)
         self.assertEqual(r, "nín-hǎo-wǒ-shì-zhōng-guó-rén")
 
-    def test_accented_text_with_non_word_characters(self):
+    def test_accented_text_with_non_word_characters(self) -> None:
         txt = 'jaja---lol-méméméoo--a'
         r = slugify(txt, allow_unicode=True)
         self.assertEqual(r, "jaja-lol-méméméoo-a")
 
-    def test_cyrillic_text(self):
+    def test_cyrillic_text(self) -> None:
         txt = 'Компьютер'
         r = slugify(txt, allow_unicode=True)
         self.assertEqual(r, "компьютер")
 
-    def test_max_length(self):
+    def test_max_length(self) -> None:
         txt = 'jaja---lol-méméméoo--a'
         r = slugify(txt, allow_unicode=True, max_length=9)
         self.assertEqual(r, "jaja-lol")
@@ -287,12 +294,12 @@ class TestSlugifyUnicode(unittest.TestCase):
         r = slugify(txt, allow_unicode=True, max_length=15)
         self.assertEqual(r, "jaja-lol-mémémé")
 
-    def test_max_length_cutoff_not_required(self):
+    def test_max_length_cutoff_not_required(self) -> None:
         txt = 'jaja---lol-méméméoo--a'
         r = slugify(txt, allow_unicode=True, max_length=50)
         self.assertEqual(r, "jaja-lol-méméméoo-a")
 
-    def test_word_boundary(self):
+    def test_word_boundary(self) -> None:
         txt = 'jaja---lol-méméméoo--a'
         r = slugify(txt, allow_unicode=True, max_length=15, word_boundary=True)
         self.assertEqual(r, "jaja-lol-a")
@@ -309,17 +316,17 @@ class TestSlugifyUnicode(unittest.TestCase):
         r = slugify(txt, allow_unicode=True, max_length=19, word_boundary=True)
         self.assertEqual(r, "jaja-lol-méméméoo-a")
 
-    def test_custom_separator(self):
+    def test_custom_separator(self) -> None:
         txt = 'jaja---lol-méméméoo--a'
         r = slugify(txt, allow_unicode=True, max_length=20, word_boundary=True, separator=".")
         self.assertEqual(r, "jaja.lol.méméméoo.a")
 
-    def test_multi_character_separator(self):
+    def test_multi_character_separator(self) -> None:
         txt = 'jaja---lol-méméméoo--a'
         r = slugify(txt, allow_unicode=True, max_length=20, word_boundary=True, separator="ZZZZZZ")
         self.assertEqual(r, "jajaZZZZZZlolZZZZZZméméméooZZZZZZa")
 
-    def test_save_order(self):
+    def test_save_order(self) -> None:
         txt = 'one two three four five'
         r = slugify(txt, allow_unicode=True, max_length=13, word_boundary=True, save_order=True)
         self.assertEqual(r, "one-two-three")
@@ -336,7 +343,7 @@ class TestSlugifyUnicode(unittest.TestCase):
         r = slugify(txt, allow_unicode=True, max_length=12, word_boundary=True, save_order=True)
         self.assertEqual(r, "one-two")
 
-    def test_save_order_rtl(self):
+    def test_save_order_rtl(self) -> None:
         """For right-to-left unicode languages"""
         txt = 'دو سه چهار پنج'
         r = slugify(txt, allow_unicode=True, max_length=10, word_boundary=True, save_order=True)
@@ -354,7 +361,7 @@ class TestSlugifyUnicode(unittest.TestCase):
         r = slugify(txt, allow_unicode=True, max_length=9, word_boundary=True, save_order=True)
         self.assertEqual(r, "دو-سه")
 
-    def test_stopword_removal(self):
+    def test_stopword_removal(self) -> None:
         txt = 'this has a stopword'
         r = slugify(txt, allow_unicode=True, stopwords=['stopword'])
         self.assertEqual(r, 'this-has-a')
@@ -363,7 +370,7 @@ class TestSlugifyUnicode(unittest.TestCase):
         r = slugify(txt, allow_unicode=True, stopwords=['Öländ'])
         self.assertEqual(r, 'this-has-a')
 
-    def test_stopword_removal_casesensitive(self):
+    def test_stopword_removal_casesensitive(self) -> None:
         txt = 'thIs Has a stopword Stopword'
         r = slugify(txt, allow_unicode=True, stopwords=['Stopword'], lowercase=False)
         self.assertEqual(r, 'thIs-Has-a-stopword')
@@ -372,12 +379,12 @@ class TestSlugifyUnicode(unittest.TestCase):
         r = slugify(txt, allow_unicode=True, stopwords=['Öländ'], lowercase=False)
         self.assertEqual(r, 'thIs-Has-a-öländ')
 
-    def test_multiple_stopword_occurances(self):
+    def test_multiple_stopword_occurances(self) -> None:
         txt = 'the quick brown fox jumps over the lazy dog'
         r = slugify(txt, allow_unicode=True, stopwords=['the'])
         self.assertEqual(r, 'quick-brown-fox-jumps-over-lazy-dog')
 
-    def test_differently_cased_stopword_match(self):
+    def test_differently_cased_stopword_match(self) -> None:
         txt = 'Foo A FOO B foo C'
         r = slugify(txt, allow_unicode=True, stopwords=['foo'])
         self.assertEqual(r, 'a-b-c')
@@ -386,67 +393,67 @@ class TestSlugifyUnicode(unittest.TestCase):
         r = slugify(txt, allow_unicode=True, stopwords=['FOO'])
         self.assertEqual(r, 'a-b-c')
 
-    def test_multiple_stopwords(self):
+    def test_multiple_stopwords(self) -> None:
         txt = 'the quick brown fox jumps over the lazy dog in a hurry'
         r = slugify(txt, allow_unicode=True, stopwords=['the', 'in', 'a', 'hurry'])
         self.assertEqual(r, 'quick-brown-fox-jumps-over-lazy-dog')
 
-    def test_stopwords_with_different_separator(self):
+    def test_stopwords_with_different_separator(self) -> None:
         txt = 'the quick brown fox jumps over the lazy dog'
         r = slugify(txt, allow_unicode=True, stopwords=['the'], separator=' ')
         self.assertEqual(r, 'quick brown fox jumps over lazy dog')
 
-    def test_html_entities_on(self):
+    def test_html_entities_on(self) -> None:
         txt = 'foo &amp; bar'
         r = slugify(txt, allow_unicode=True)
         self.assertEqual(r, 'foo-bar')
 
-    def test_html_entities_off(self):
+    def test_html_entities_off(self) -> None:
         txt = 'foo &amp; bår'
         r = slugify(txt, allow_unicode=True, entities=False)
         self.assertEqual(r, 'foo-amp-bår')
 
-    def test_html_decimal_on(self):
+    def test_html_decimal_on(self) -> None:
         txt = '&#381;'
         r = slugify(txt, allow_unicode=True, decimal=True)
         self.assertEqual(r, 'ž')
 
-    def test_html_decimal_off(self):
+    def test_html_decimal_off(self) -> None:
         txt = '&#381;'
         r = slugify(txt, allow_unicode=True, entities=False, decimal=False)
         self.assertEqual(r, '381')
 
-    def test_html_hexadecimal_on(self):
+    def test_html_hexadecimal_on(self) -> None:
         txt = '&#x17D;'
         r = slugify(txt, allow_unicode=True, hexadecimal=True)
         self.assertEqual(r, 'ž')
 
-    def test_html_hexadecimal_off(self):
+    def test_html_hexadecimal_off(self) -> None:
         txt = '&#x17D;'
         r = slugify(txt, allow_unicode=True, hexadecimal=False)
         self.assertEqual(r, 'x17d')
 
-    def test_starts_with_number(self):
+    def test_starts_with_number(self) -> None:
         txt = '10 amazing secrets'
         r = slugify(txt, allow_unicode=True)
         self.assertEqual(r, '10-amazing-secrets')
 
-    def test_contains_numbers(self):
+    def test_contains_numbers(self) -> None:
         txt = 'buildings with 1000 windows'
         r = slugify(txt, allow_unicode=True)
         self.assertEqual(r, 'buildings-with-1000-windows')
 
-    def test_ends_with_number(self):
+    def test_ends_with_number(self) -> None:
         txt = 'recipe number 3'
         r = slugify(txt, allow_unicode=True)
         self.assertEqual(r, 'recipe-number-3')
 
-    def test_numbers_only(self):
+    def test_numbers_only(self) -> None:
         txt = '404'
         r = slugify(txt, allow_unicode=True)
         self.assertEqual(r, '404')
 
-    def test_numbers_and_symbols(self):
+    def test_numbers_and_symbols(self) -> None:
         txt = '1,000 reasons you are #1'
         r = slugify(txt, allow_unicode=True)
         self.assertEqual(r, '1000-reasons-you-are-1')
@@ -455,14 +462,14 @@ class TestSlugifyUnicode(unittest.TestCase):
         r = slugify(txt, allow_unicode=True)
         self.assertEqual(r, '۱۰۰۰-reasons-you-are-۱')
 
-    def test_regex_pattern_keep_underscore(self):
+    def test_regex_pattern_keep_underscore(self) -> None:
         """allowing unicode should not overrule the passed regex_pattern"""
         txt = "___This is a test___"
         regex_pattern = r'[^-a-z0-9_]+'
         r = slugify(txt, allow_unicode=True, regex_pattern=regex_pattern)
         self.assertEqual(r, "___this-is-a-test___")
 
-    def test_regex_pattern_keep_underscore_with_underscore_as_separator(self):
+    def test_regex_pattern_keep_underscore_with_underscore_as_separator(self) -> None:
         """
         The regex_pattern turns the power to the caller.
         Hence, the caller must ensure that a custom separator doesn't clash
@@ -473,7 +480,7 @@ class TestSlugifyUnicode(unittest.TestCase):
         r = slugify(txt, allow_unicode=True, separator='_', regex_pattern=regex_pattern)
         self.assertNotEqual(r, "_this_is_a_test_")
 
-    def test_replacements(self):
+    def test_replacements(self) -> None:
         txt = '10 | 20 %'
         r = slugify(txt, allow_unicode=True, replacements=[['|', 'or'], ['%', 'percent']])
         self.assertEqual(r, "10-or-20-percent")
@@ -486,12 +493,12 @@ class TestSlugifyUnicode(unittest.TestCase):
         r = slugify(txt, allow_unicode=True, replacements=[['♥', 'სიყვარული'], ['🦄', 'licorne']])
         self.assertEqual(r, "i-სიყვარული-licorne")
 
-    def test_replacements_german_umlaut_custom(self):
+    def test_replacements_german_umlaut_custom(self) -> None:
         txt = 'ÜBER Über German Umlaut'
         r = slugify(txt, allow_unicode=True, replacements=[['Ü', 'UE'], ['ü', 'ue']])
         self.assertEqual(r, "ueber-ueber-german-umlaut")
 
-    def test_emojis(self):
+    def test_emojis(self) -> None:
         """
         allowing unicode shouldn't allow emojis, even in replacements.
         the only exception is when it is allowed by the regex_pattern. regex_pattern overrules all
@@ -523,38 +530,18 @@ class TestSlugifyUnicode(unittest.TestCase):
 
 class TestUtils(unittest.TestCase):
 
-    def test_smart_truncate_no_max_length(self):
+    def test_smart_truncate_no_max_length(self) -> None:
         txt = '1,000 reasons you are #1'
         r = smart_truncate(txt)
         self.assertEqual(r, txt)
 
-    def test_smart_truncate_no_seperator(self):
+    def test_smart_truncate_no_seperator(self) -> None:
         txt = '1,000 reasons you are #1'
         r = smart_truncate(txt, max_length=100, separator='_')
         self.assertEqual(r, txt)
 
 
 PY3 = sys.version_info.major == 3
-
-
-@contextmanager
-def captured_stderr():
-    backup = sys.stderr
-    sys.stderr = io.StringIO() if PY3 else io.BytesIO()
-    try:
-        yield sys.stderr
-    finally:
-        sys.stderr = backup
-
-
-@contextmanager
-def loaded_stdin(contents):
-    backup = sys.stdin
-    sys.stdin = io.StringIO(contents) if PY3 else io.BytesIO(contents)
-    try:
-        yield sys.stdin
-    finally:
-        sys.stdin = backup
 
 
 class TestCommandParams(unittest.TestCase):
@@ -571,74 +558,74 @@ class TestCommandParams(unittest.TestCase):
         'replacements': None
     }
 
-    def get_params_from_cli(self, *argv):
+    def get_params_from_cli(self, *argv: Any) -> SlugifyParams:
         args = parse_args([None] + list(argv))
         return slugify_params(args)
 
-    def make_params(self, **values):
+    def make_params(self, **values: Any) -> dict[Any, Any]:
         return dict(self.DEFAULTS, **values)
 
-    def assertParamsMatch(self, expected, checked):
+    def assertParamsMatch(self, expected: dict[Any, Any], checked: SlugifyParams) -> None:
         reduced_checked = {}
         for key in expected.keys():
             reduced_checked[key] = checked[key]
         self.assertEqual(expected, reduced_checked)
 
-    def test_defaults(self):
+    def test_defaults(self) -> None:
         params = self.get_params_from_cli()
         self.assertParamsMatch(self.DEFAULTS, params)
 
-    def test_negative_flags(self):
+    def test_negative_flags(self) -> None:
         params = self.get_params_from_cli('--no-entities', '--no-decimal', '--no-hexadecimal', '--no-lowercase')
         expected = self.make_params(entities=False, decimal=False, hexadecimal=False, lowercase=False)
         self.assertFalse(expected['lowercase'])
         self.assertFalse(expected['word_boundary'])
         self.assertParamsMatch(expected, params)
 
-    def test_affirmative_flags(self):
+    def test_affirmative_flags(self) -> None:
         params = self.get_params_from_cli('--word-boundary', '--save-order')
         expected = self.make_params(word_boundary=True, save_order=True)
         self.assertParamsMatch(expected, params)
 
-    def test_valued_arguments(self):
+    def test_valued_arguments(self) -> None:
         params = self.get_params_from_cli('--stopwords', 'abba', 'beatles', '--max-length', '98', '--separator', '+')
         expected = self.make_params(stopwords=['abba', 'beatles'], max_length=98, separator='+')
         self.assertParamsMatch(expected, params)
 
-    def test_replacements_right(self):
+    def test_replacements_right(self) -> None:
         params = self.get_params_from_cli('--replacements', 'A->B', 'C->D')
         expected = self.make_params(replacements=[['A', 'B'], ['C', 'D']])
         self.assertParamsMatch(expected, params)
 
-    def test_replacements_wrong(self):
-        with self.assertRaises(SystemExit) as err, captured_stderr() as cse:
+    def test_replacements_wrong(self) -> None:
+        with self.assertRaises(SystemExit) as err, mock.patch("sys.stderr", new_callable=io.StringIO) as cse:
             self.get_params_from_cli('--replacements', 'A--B')
         self.assertEqual(err.exception.code, 2)
         self.assertIn("Replacements must be of the form: ORIGINAL->REPLACED", cse.getvalue())
 
-    def test_text_in_cli(self):
+    def test_text_in_cli(self) -> None:
         params = self.get_params_from_cli('Cool Text')
         expected = self.make_params(text='Cool Text')
         self.assertParamsMatch(expected, params)
 
-    def test_text_in_cli_multi(self):
+    def test_text_in_cli_multi(self) -> None:
         params = self.get_params_from_cli('Cool', 'Text')
         expected = self.make_params(text='Cool Text')
         self.assertParamsMatch(expected, params)
 
-    def test_text_in_stdin(self):
-        with loaded_stdin("Cool Stdin"):
+    def test_text_in_stdin(self) -> None:
+        with mock.patch('sys.stdin.read', side_effect=['Cool Stdin']):
             params = self.get_params_from_cli('--stdin')
         expected = self.make_params(text='Cool Stdin')
         self.assertParamsMatch(expected, params)
 
-    def test_two_text_sources_fails(self):
-        with self.assertRaises(SystemExit) as err, captured_stderr() as cse:
+    def test_two_text_sources_fails(self) -> None:
+        with self.assertRaises(SystemExit) as err, mock.patch("sys.stderr", new_callable=io.StringIO) as cse:
             self.get_params_from_cli('--stdin', 'Text')
         self.assertEqual(err.exception.code, 2)
         self.assertIn("Input strings and --stdin cannot work together", cse.getvalue())
 
-    def test_multivalued_options_with_text(self):
+    def test_multivalued_options_with_text(self) -> None:
         text = "the quick brown fox jumps over the lazy dog in a hurry"
         cli_args = "--stopwords the in a hurry -- {}".format(text).split()
         params = self.get_params_from_cli(*cli_args)


### PR DESCRIPTION
Enables `mypy --strict` and types everything to be mostly compliant. There are a few, internal ignores mostly because they either require refactoring or extra dependencies (like [typing-extensions](https://pypi.org/project/typing-extensions/) for older python versions).

I tried to minimize behavioral changes, though there are some. Can address the TODOs introduced here to achieve stronger type-safety or I can follow up with a separate change if desired.

This is pushed to HEAD of my fork and you can observe CI approves, https://github.com/jmelahman/python-slugify/actions/runs/5779513831