### PR TITLE
Fix uppercase pre-translations

### DIFF
--- a/slugify/special.py
+++ b/slugify/special.py
@@ -9,7 +9,6 @@ def add_uppercase_char(char_list: list[tuple[str, str]]) -> list[tuple[str, str]
         upper_dict = char.upper(), xlate.capitalize()
         if upper_dict not in char_list and char != upper_dict[0]:
             char_list.insert(0, upper_dict)
-        return char_list
     return char_list
 
 

--- a/test.py
+++ b/test.py
@@ -4,6 +4,7 @@ import sys
 import unittest
 from contextlib import contextmanager
 
+from slugify import PRE_TRANSLATIONS
 from slugify import slugify
 from slugify import smart_truncate
 from slugify.__main__ import slugify_params, parse_args
@@ -236,6 +237,8 @@ class TestSlugify(unittest.TestCase):
         r = slugify(txt, replacements=[['Ü', 'UE'], ['ü', 'ue']])
         self.assertEqual(r, "ueber-ueber-german-umlaut")
 
+    def test_pre_translation(self):
+        self.assertEqual(PRE_TRANSLATIONS, [('Ю', 'U'), ('Щ', 'Sch'), ('У', 'Y'), ('Х', 'H'), ('Я', 'Ya'), ('Ё', 'E'), ('ё', 'e'), ('я', 'ya'), ('х', 'h'), ('у', 'y'), ('щ', 'sch'), ('ю', 'u'), ('Ü', 'Ue'), ('Ö', 'Oe'), ('Ä', 'Ae'), ('ä', 'ae'), ('ö', 'oe'), ('ü', 'ue'), ('Ϋ́', 'Y'), ('Ϋ', 'Y'), ('Ύ', 'Y'), ('Υ', 'Y'), ('Χ', 'Ch'), ('χ', 'ch'), ('Ξ', 'X'), ('ϒ', 'Y'), ('υ', 'y'), ('ύ', 'y'), ('ϋ', 'y'), ('ΰ', 'y')])
 
 class TestSlugifyUnicode(unittest.TestCase):
 


### PR DESCRIPTION
before
```python
>>> from slugify import PRE_TRANSLATIONS
>>> print(PRE_TRANSLATIONS)
[('Ё', 'E'), ('ё', 'e'), ('я', 'ya'), ('х', 'h'), ('у', 'y'), ('щ', 'sch'), ('ю', 'u'), ('Ä', 'Ae'), ('ä', 'ae'), ('ö', 'oe'), ('ü', 'ue'), ('Χ', 'Ch'), ('χ', 'ch'), ('Ξ', 'X'), ('ϒ', 'Y'), ('υ', 'y'), ('ύ', 'y'), ('ϋ', 'y'), ('ΰ', 'y')]
```

after

```python
>>> from slugify import PRE_TRANSLATIONS
>>> print(PRE_TRANSLATIONS)
[('Ю', 'U'), ('Щ', 'Sch'), ('У', 'Y'), ('Х', 'H'), ('Я', 'Ya'), ('Ё', 'E'), ('ё', 'e'), ('я', 'ya'), ('х', 'h'), ('у', 'y'), ('щ', 'sch'), ('ю', 'u'), ('Ü', 'Ue'), ('Ö', 'Oe'), ('Ä', 'Ae'), ('ä', 'ae'), ('ö', 'oe'), ('ü', 'ue'), ('Ϋ́', 'Y'), ('Ϋ', 'Y'), ('Ύ', 'Y'), ('Υ', 'Y'), ('Χ', 'Ch'), ('χ', 'ch'), ('Ξ', 'X'), ('ϒ', 'Y'), ('υ', 'y'), ('ύ', 'y'), ('ϋ', 'y'), ('ΰ', 'y')]
```