### PR TITLE
Remove references to `easy_install`, which is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,11 @@ However, there is an alternative decoding package called [Unidecode](https://git
 
 # How to install
 
-    easy_install python-slugify |OR| easy_install python-slugify[unidecode]
-    -- OR --
-    pip install python-slugify |OR| pip install python-slugify[unidecode]
+    pip install python-slugify
+
+    # OR
+
+    pip install python-slugify[unidecode]
 
 # Options
 


### PR DESCRIPTION
This PR removes references to `easy_install` in the README.

[`easy_install` is deprecated](https://setuptools.pypa.io/en/latest/deprecated/easy_install.html), and users are explicitly warned not to use it.
