### PR TITLE
Fix CI by dropping EOL Python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.7, 3.8, 3.9, "3.10", 3.11, 3.12, 3.13, pypy3.10]
+        python:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
+          - "pypy3.11"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -14,7 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.7, 3.8, 3.9, "3.10", 3.11, 3.12, 3.13, pypy3.10]
+        python:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
+          - "pypy3.11"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.7, 3.8, 3.9, "3.10", 3.11, 3.12, 3.13, pypy3.10]
+        python:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
+          - "pypy3.11"
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+- Support Python 3.14.
+- Drop support for Python 3.9 and lower.
+
 ## 8.0.4
 
 - Properly handle uppercase special characters (@mib1185 - thx)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 
 
 package = 'slugify'
-python_requires = ">=3.7"
+python_requires = ">=3.10"
 here = os.path.abspath(os.path.dirname(__file__))
 
 install_requires = ['text-unidecode>=1.3']
@@ -78,13 +78,11 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
     ],
     entry_points={'console_scripts': ['slugify=slugify.__main__:main']},
 )


### PR DESCRIPTION
This introduces the following changes:

- Support Python 3.14.
- Drop support for Python 3.9 and lower.

@Arian-Ott, happy new year! Fixing CI, as well as fixing the build process (#159), are critical project infrastructure needs, and I hope you can take a look at both when you have an opportunity!