### PR TITLE
Fix the README badge to refer to the `main.yml` workflow results

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ X.Y.Z Version
     `MINOR` version -- when you add functionality in a backwards-compatible manner, and
     `PATCH` version -- when you make backwards-compatible bug fixes.
 
-[status-image]: https://github.com/un33k/python-slugify/actions/workflows/ci.yml/badge.svg
+[status-image]: https://github.com/un33k/python-slugify/actions/workflows/main.yml/badge.svg
 [status-link]: https://github.com/un33k/python-slugify/actions/workflows/ci.yml
 [version-image]: https://img.shields.io/pypi/v/python-slugify.svg
 [version-link]: https://pypi.python.org/pypi/python-slugify


### PR DESCRIPTION
This fixes the CI badge in the README, which was pointing to the CI results in the `ci` branch (which are currently failing).

I generally recommend against including badges in the README, as they are permanently locked when publishing to PyPI and can cause the PyPI page to look like the project is unhealthy (for example, if the badge hosting service closes shop, or if CI starts failing).

[In fact, this is currently the case](https://pypi.org/project/python-slugify/), and can only be fixed by publishing a new release of the package.

> <img width="1120" height="486" alt="image" src="https://github.com/user-attachments/assets/463a9a4b-d485-4f12-bc5c-ac89b884b4a5" />

* If the badges should be removed, let me know.
* Separately, if the triplicated GitHub workflows should be unified down to just one YAML file, let me know.