### PR TITLE
Fix --regex-pattern being ignored by the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Fix `--regex-pattern` being ignored by the CLI.
 - Support Python 3.14.
 - Drop support for Python 3.9 and lower.
 - Use tox for local test runs and in CI.

--- a/slugify/__main__.py
+++ b/slugify/__main__.py
@@ -76,6 +76,7 @@ def slugify_params(args: argparse.Namespace) -> dict[str, Any]:
         save_order=args.save_order,
         separator=args.separator,
         stopwords=args.stopwords,
+        regex_pattern=args.regex_pattern,
         lowercase=args.lowercase,
         replacements=args.replacements,
         allow_unicode=args.allow_unicode

--- a/test.py
+++ b/test.py
@@ -575,7 +575,8 @@ class TestCommandParams(unittest.TestCase):
         'separator': '-',
         'stopwords': None,
         'lowercase': True,
-        'replacements': None
+        'replacements': None,
+        'regex_pattern': None
     }
 
     def get_params_from_cli(self, *argv):
@@ -622,6 +623,12 @@ class TestCommandParams(unittest.TestCase):
             self.get_params_from_cli('--replacements', 'A--B')
         self.assertEqual(err.exception.code, 2)
         self.assertIn("Replacements must be of the form: ORIGINAL->REPLACED", cse.getvalue())
+
+    def test_regex_pattern(self):
+        params = self.get_params_from_cli('--regex-pattern', '[^-a-z0-9_]+', '___This is a test___')
+        expected = self.make_params(text='___This is a test___', regex_pattern='[^-a-z0-9_]+')
+        self.assertParamsMatch(expected, params)
+        self.assertEqual(slugify(**params), '___this-is-a-test___')
 
     def test_text_in_cli(self):
         params = self.get_params_from_cli('Cool Text')


### PR DESCRIPTION
## Summary

- The `--regex-pattern` CLI option was parsed by argparse but never forwarded into the `slugify()` call in
`slugify_params`, so it had no effect.
- Forward `regex_pattern` from the parsed args, add a `TestCommandParams.test_regex_pattern` regression test, and include `regex_pattern` in the test defaults.
- Update Changelog.

Fixes #175.